### PR TITLE
Adding polyfill for String.prototype.replaceAll

### DIFF
--- a/IceEd.html
+++ b/IceEd.html
@@ -528,6 +528,9 @@ const RecipeDataColumns = ["Water", "Sugar", "Fat", "MSNF", "Solids", "PAC", "PO
 const RecipeColumns = ["Name", "Amount", "Scale to", ""].concat( RecipeDataColumns );
 const IngredientDataFields = ["Water", "Sugar", "Fat", "MSNF", "Solids", "PAC", "POD", "kcal"];
 
+// replaceAll is currently not everywhere available. Use this polyfill from https://stackoverflow.com/a/14822579
+String.prototype.replaceAll = String.prototype.replaceAll || function (find, replace) { var str = this; return str.replace(new RegExp(find.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&'), 'g'), replace); };
+
 // Init tab handlers
 Array.from(document.getElementsByClassName("tablink")).forEach( tablink => {
     tablink.onclick=function(event)


### PR DESCRIPTION
The current implementation relies on the existence of `String.prototype.replaceAll` which is not (yet) widely available. 

This commit introduces a polyfill so that the tool can also be run in other browsers, not only Firefox.